### PR TITLE
Apply custom colors to home page cards

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -24,29 +24,29 @@ import is6Banner from '../../assets/CN_Suis_Garden_of_Grotesqueries_banner.png';
 ## Select an Integrated Strategies Theme
 
 <CardGrid>
-	<Card title="" icon="puzzle-piece">
-		<a href="/is2-phantom/overview/">
-			<img src={is2Banner.src} alt="Phantom & Crimson Solitaire Banner" />
-		</a>
-	</Card>
-	<Card title="" icon="waves">
-		<a href="/is3-mizuki/overview/">
-			<img src={is3Banner.src} alt="Mizuki & Caerula Arbor Banner" />
-		</a>
-	</Card>
-	<Card title="" icon="compass">
-		<a href="/is4-expeditioners/overview/">
-			<img src={is4Banner.src} alt="Expeditioner's Joklumarkar Banner" />
-		</a>
-	</Card>
+        <Card title="" icon="puzzle-piece">
+                <a href="/is2-phantom/overview/">
+                        <img src={is2Banner.src} alt="Phantom & Crimson Solitaire Banner" />
+                </a>
+        </Card>
+        <Card title="" icon="waves">
+                <a href="/is3-mizuki/overview/">
+                        <img src={is3Banner.src} alt="Mizuki & Caerula Arbor Banner" />
+                </a>
+        </Card>
+        <Card title="" icon="compass">
+                <a href="/is4-expeditioners/overview/">
+                        <img src={is4Banner.src} alt="Expeditioner's Joklumarkar Banner" />
+                </a>
+        </Card>
     <Card title="" icon="flame">
-		<a href="/is5-sarkaz/overview/">
-			<img src={is5Banner.src} alt="Sarkaz's Furnaceside Fables Banner" />
-		</a>
-	</Card>
+                <a href="/is5-sarkaz/overview/">
+                        <img src={is5Banner.src} alt="Sarkaz's Furnaceside Fables Banner" />
+                </a>
+        </Card>
     <Card title="" icon="potted-plant">
-		<a href="/is6-sui/overview/">
-			<img src={is6Banner.src} alt="Sui's Garden of Grotesqueries Banner" />
-		</a>
-	</Card>
+                <a href="/is6-sui/overview/">
+                        <img src={is6Banner.src} alt="Sui's Garden of Grotesqueries Banner" />
+                </a>
+        </Card>
 </CardGrid>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -45,33 +45,28 @@
 }
 
 /* --- Custom Banner Icon Colors --- */
-
-/* IS2: Phantom & Crimson Solitaire */
-.sl-card-icon-puzzle-piece .icon {
-	background-color: #B71C1C !important; /* Deep red from Phantom's coat */
-	color: white !important;
+.card-grid .card:nth-child(1) .icon {
+    background-color: #B71C1C !important;
+    border-color: #B71C1C !important;
+    color: white !important;
 }
-
-/* IS3: Mizuki & Caerula Arbor */
-.sl-card-icon-waves .icon {
-	background-color: #3949AB !important; /* Deep blue from the water */
-	color: white !important;
+.card-grid .card:nth-child(2) .icon {
+    background-color: #3949AB !important;
+    border-color: #3949AB !important;
+    color: white !important;
 }
-
-/* IS4: Expeditioner's Joklumarkar */
-.sl-card-icon-compass .icon {
-	background-color: #64B5F6 !important; /* Icy blue from the environment */
-	color: white !important;
+.card-grid .card:nth-child(3) .icon {
+    background-color: #64B5F6 !important;
+    border-color: #64B5F6 !important;
+    color: white !important;
 }
-
-/* IS5: Sarkaz's Furnaceside Fables */
-.sl-card-icon-flame .icon {
-	background-color: #FBC02D !important; /* Gold from the stage lights */
-	color: black !important;
+.card-grid .card:nth-child(4) .icon {
+    background-color: #FBC02D !important;
+    border-color: #FBC02D !important;
+    color: black !important;
 }
-
-/* IS6: Sui's Garden of Grotesqueries */
-.sl-card-icon-potted-plant .icon {
-	background-color: #EC407A !important; /* Pink from the lotus flowers */
-	color: white !important;
+.card-grid .card:nth-child(5) .icon {
+    background-color: #EC407A !important;
+    border-color: #EC407A !important;
+    color: white !important;
 }


### PR DESCRIPTION
## Summary
- remove obsolete icon color overrides
- add nth-child CSS rules to give each card a specific color

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a389e14d388330839fbf2c0ac6c47d